### PR TITLE
fix moving_sum_ff() and add gnuradio-filter library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ find_package(Doxygen)
 # caps such as FILTER or FFT) and change the version to the minimum
 # API compatible version required.
 set(GR_REQUIRED_COMPONENTS RUNTIME FILTER)
-find_package(Gnuradio "3.7.2" REQUIRED)
+find_package(Gnuradio "3.7.1" REQUIRED)
 
 if(NOT CPPUNIT_FOUND)
     message(FATAL_ERROR "CppUnit required to compile dab")
@@ -123,6 +123,7 @@ link_directories(
     ${Boost_LIBRARY_DIRS}
     ${CPPUNIT_LIBRARY_DIRS}
     ${GNURADIO_RUNTIME_LIBRARY_DIRS}
+    ${GNURADIO_FILTER_LIBRARY_DIRS}
 )
 
 # Set component parameters

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,7 +60,7 @@ if(NOT dab_sources)
 endif(NOT dab_sources)
 
 add_library(gnuradio-dab SHARED ${dab_sources})
-target_link_libraries(gnuradio-dab ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES})
+target_link_libraries(gnuradio-dab ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES} ${GNURADIO_FILTER_LIBRARIES})
 set_target_properties(gnuradio-dab PROPERTIES DEFINE_SYMBOL "gnuradio_dab_EXPORTS")
 
 if(APPLE)
@@ -92,9 +92,11 @@ list(APPEND test_dab_sources
 
 add_executable(test-dab ${test_dab_sources})
 
+
 target_link_libraries(
   test-dab
   ${GNURADIO_RUNTIME_LIBRARIES}
+  ${GNURADIO_FILTER_LIBRARIES}
   ${Boost_LIBRARIES}
   ${CPPUNIT_LIBRARIES}
   gnuradio-dab

--- a/python/detect_null.py
+++ b/python/detect_null.py
@@ -22,7 +22,7 @@
 # andrmuel@ee.ethz.ch
 
 from gnuradio import gr, blocks
-import dab
+from dab import dab_swig
 
 class detect_null(gr.hier_block2):
 	"""
@@ -52,7 +52,7 @@ class detect_null(gr.hier_block2):
 		# this isn't better:
 		#self.ns_filter = gr.iir_filter_ffd([1]+[0]*(length-1)+[-1],[0,1])
 		# this does the same again, but is actually faster (outsourced to an independent block ..):
-		self.ns_moving_sum = dab.moving_sum_ff(length)
+		self.ns_moving_sum = dab_swig.moving_sum_ff(length)
 		self.ns_invert = blocks.multiply_const_ff(-1)
 
 		# peak detector on the inverted, summed up signal -> we get the nulls (i.e. the position of the start of a frame)

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -43,6 +43,10 @@ foreach(incdir ${GNURADIO_RUNTIME_INCLUDE_DIRS})
     list(APPEND GR_SWIG_INCLUDE_DIRS ${incdir}/gnuradio/swig)
 endforeach(incdir)
 
+foreach(incdir ${GNURADIO_FILTER_INCLUDE_DIRS})
+    list(APPEND GR_SWIG_INCLUDE_DIRS ${incdir}/gnuradio/swig)
+endforeach(incdir)
+
 set(GR_SWIG_LIBRARIES gnuradio-dab)
 set(GR_SWIG_DOC_FILE ${CMAKE_CURRENT_BINARY_DIR}/dab_swig_doc.i)
 set(GR_SWIG_DOC_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../include)


### PR DESCRIPTION
This patch solving 2 problems I found on ubuntu-12.04 with installed gnuradio-3.7.1

* Since filters are moved from default gnuradio library, we need to add it's path to CMakeLists.txt
* python/detect_null.py using moving_sum_ff(), but it's not seen from dab directly, only from dab.dab_swig.



```
gr-dab/apps$ ./rtl_sdr_dab_rx_constellation.py 
linux; GNU C++ version 4.6.3; Boost_104800; UHD_003.005.003-0-unknown

Traceback (most recent call last):
  File "./rtl_sdr_dab_rx_constellation.py", line 18, in <module>
    import dab
  File "/usr/lib/python2.7/dist-packages/dab/__init__.py", line 36, in <module>
    from detect_null import detect_null
  File "/usr/lib/python2.7/dist-packages/dab/detect_null.py", line 25, in <module>
    from dab import dab_swig
  File "/usr/lib/python2.7/dist-packages/dab/dab_swig.py", line 26, in <module>
    _dab_swig = swig_import_helper()
  File "/usr/lib/python2.7/dist-packages/dab/dab_swig.py", line 22, in swig_import_helper
    _mod = imp.load_module('_dab_swig', fp, pathname, description)
ImportError: /usr/lib/libgnuradio-dab.so: undefined symbol: _ZN2gr6filter24mmse_fir_interpolator_ccD1Ev
```