### PR TITLE
Install cmake file under correct libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,5 +170,5 @@ add_subdirectory(docs)
 # Install cmake search helper for this library
 ########################################################################
 install(FILES cmake/Modules/dabConfig.cmake
-    DESTINATION lib/cmake/grdab
+    DESTINATION lib${LIB_SUFFIX}/cmake/grdab
 )


### PR DESCRIPTION
E.g. Fedora uses lib64 not lib.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>